### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/mastfissh/safety_matrix_mobile/security/code-scanning/2](https://github.com/mastfissh/safety_matrix_mobile/security/code-scanning/2)

To fix the issue, add a `permissions` block explicitly to the workflow. The minimal required permissions for a standard CI job that only checks out and tests code is `contents: read`. You can add the following block either at the workflow root (to affect all jobs), or at the individual job level; adding it at the root is preferred for clarity unless there is a need for finer-grained controls per job. The change should be made near the top—below `name:` and above `on:`.

**Steps:**
- Edit `.github/workflows/node.js.yml`
- Add the following lines:
  ```yaml
  permissions:
    contents: read
  ```
  Place these lines after the `name:` line and before the `on:` block.

No additional methods, imports, or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
