### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/eas.js.yml
+++ b/.github/workflows/eas.js.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches:
       - release
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mastfissh/safety_matrix_mobile/security/code-scanning/1](https://github.com/mastfissh/safety_matrix_mobile/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block at either the workflow root or the job level. The minimal permissions required for general usage are `contents: read`. This should be added as a new root-level field above `jobs:` (after any top-level workflow fields, such as `on:`), so that it applies to all jobs unless otherwise overridden. 

This ensures the GITHUB_TOKEN used by Actions in this workflow will only have read-only access to repository contents by default. This does not affect the other steps in the workflow, none of which appear to require write access to the repository.

No new files or additional methods/imports are required; this is a simple YAML keys/indentation update.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
